### PR TITLE
Upgrade to Kotlin 2.3.21

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ For more details, see [What does it do (in detail)?](#what-does-it-do-in-detail)
 | 2.2.21         | 1.4.x (latest 1.4.3) |
 | 2.3.0          | 1.5.x (latest 1.5.1) |
 | 2.3.10         | 1.5.x (latest 1.5.1) |
-| 2.3.20         | 1.6.x (latest 1.6.0) |
+| 2.3.20         | 1.6.x (latest 1.6.1) |
+| 2.3.21         | 1.6.x (latest 1.6.1) |
 
 ## Usage
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlinversion = "2.3.20"
+kotlinversion = "2.3.21"
 ktfmt = "0.47"
 dokka = "2.2.0"
 build-config = "6.0.9"


### PR DESCRIPTION
Notes:
* kotlin-compiler-extensions stays at 0.13.0+2.3.20 because no 2.3.21-matched build has been published yet;
* 2.3.21 is a patch release and the full test suite (4100 tests) passes with the 2.3.20-built extensions.
* Next release will be 1.6.1 (version is already at 1.6.1-SNAPSHOT).