### PR TITLE
Upgrade to Kotlin 2.4.0 and prepare to release 1.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ For more details, see [What does it do (in detail)?](#what-does-it-do-in-detail)
 | 2.3.10         | 1.5.x (latest 1.5.1) |
 | 2.3.20         | 1.6.x (latest 1.6.1) |
 | 2.3.21         | 1.6.x (latest 1.6.1) |
+| 2.4.0          | 1.7.x (latest 1.7.0) |
 
 ## Usage
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ plugins {
 
 allprojects {
   group = "dev.nemecec.kotlinlogging.compiletimeplugin"
-  version = "1.6.2-SNAPSHOT"
+  version = "1.7.0-SNAPSHOT"
 
   configurations.configureEach {
     resolutionStrategy.eachDependency {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,15 +1,15 @@
 [versions]
-kotlinversion = "2.3.21"
+kotlinversion = "2.4.0"
 ktfmt = "0.47"
 dokka = "2.2.0"
-build-config = "6.0.9"
+build-config = "6.0.10"
 maven-publish = "0.36.0"
 spotless = "8.6.0"
 
 auto-service = "1.1.1"
-kotlin-compiler-extensions = "0.13.0+2.3.20"
+kotlin-compiler-extensions = "0.15.0+2.4.0"
 junit-jupiter = "6.1.0"
-kctfork = "0.12.1"
+kctfork = "0.13.0"
 kotlin-logging-jvm = "8.0.4"
 logback = "1.5.34"
 

--- a/kotlin-plugin/build.gradle.kts
+++ b/kotlin-plugin/build.gradle.kts
@@ -47,7 +47,6 @@ tasks {
 kotlin {
   compilerOptions {
     javaParameters = true
-    freeCompilerArgs.add("-Xcontext-parameters")
   }
 }
 

--- a/kotlin-plugin/src/main/kotlin/dev/nemecec/kotlinlogging/compiletimeplugin/KotlinLoggingIrGenerationExtension.kt
+++ b/kotlin-plugin/src/main/kotlin/dev/nemecec/kotlinlogging/compiletimeplugin/KotlinLoggingIrGenerationExtension.kt
@@ -6,6 +6,7 @@ import com.javiersc.kotlin.compiler.extensions.ir.createLambdaIrSimpleFunction
 import com.javiersc.kotlin.compiler.extensions.ir.toIrConstructorCall
 import org.jetbrains.kotlin.backend.common.FileLoweringPass
 import org.jetbrains.kotlin.backend.common.IrElementTransformerVoidWithContext
+import org.jetbrains.kotlin.backend.common.extensions.DeclarationFinder
 import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
@@ -105,7 +106,8 @@ class KotlinLoggingIrGenerationExtension(
   override fun generate(moduleFragment: IrModuleFragment, pluginContext: IrPluginContext) {
     messageCollector.report(CompilerMessageSeverity.INFO, "Plugin config: $config")
     if (!config.disableAll) {
-      if (!pluginContext.kotlinLoggingIsAvailable()) {
+      val firstFile = moduleFragment.files.firstOrNull() ?: return
+      if (!pluginContext.finderForSource(firstFile).kotlinLoggingIsAvailable()) {
         messageCollector.report(
           severity = CompilerMessageSeverity.WARNING,
           message =
@@ -121,6 +123,7 @@ class KotlinLoggingIrGenerationExtension(
             loggingApiVersion,
             SourceFile(file),
             pluginContext,
+            pluginContext.finderForSource(file),
             messageCollector,
           )
           .runOnFileInOrder(file)
@@ -143,27 +146,25 @@ class KotlinLoggingIrGenerationExtension(
     }
   }
 
-  private fun IrPluginContext.kotlinLoggingIsAvailable() =
-    referenceClass(ClassId(FqName(PACKAGE_NAME), Name.identifier("Level"))) != null
+  private fun DeclarationFinder.kotlinLoggingIsAvailable() =
+    findClass(ClassId(FqName(PACKAGE_NAME), Name.identifier("Level"))) != null
 
-  class TypesHelper(val context: IrPluginContext) {
+  class TypesHelper(val context: IrPluginContext, finder: DeclarationFinder) {
 
     val atMethodName = Name.identifier("at")
     val extensionReceiverParameterName = Name.identifier("\$this\$at")
 
     val levelClassSymbol =
-      context.referenceClass(ClassId(FqName(PACKAGE_NAME), Name.identifier("Level")))!!
+      finder.findClass(ClassId(FqName(PACKAGE_NAME), Name.identifier("Level")))!!
     val markerClassSymbol =
-      context.referenceClass(ClassId(FqName(PACKAGE_NAME), Name.identifier("Marker")))!!
+      finder.findClass(ClassId(FqName(PACKAGE_NAME), Name.identifier("Marker")))!!
     val markerType = markerClassSymbol.defaultType
     val throwableType = context.irBuiltIns.throwableType
 
     val function1Class = context.irBuiltIns.functionN(1)
     val unitType = context.irBuiltIns.unitType
     val eventBuilderClassSymbol =
-      context.referenceClass(
-        ClassId(FqName(PACKAGE_NAME), Name.identifier("KLoggingEventBuilder"))
-      )!!
+      finder.findClass(ClassId(FqName(PACKAGE_NAME), Name.identifier("KLoggingEventBuilder")))!!
     val eventBuilderLambdaType =
       function1Class.typeWith(eventBuilderClassSymbol.defaultType, unitType)
     @OptIn(UnsafeDuringIrConstructionAPI::class)
@@ -171,7 +172,7 @@ class KotlinLoggingIrGenerationExtension(
     @OptIn(UnsafeDuringIrConstructionAPI::class)
     val setCauseFunction = eventBuilderClassSymbol.owner.getPropertySetter("cause")!!
     val internalCompilerDataClassSymbol =
-      context.referenceClass(
+      finder.findClass(
         ClassId(
           FqName(PACKAGE_NAME),
           FqName("KLoggingEventBuilder.InternalCompilerData"),
@@ -180,8 +181,8 @@ class KotlinLoggingIrGenerationExtension(
       )!!
     @OptIn(UnsafeDuringIrConstructionAPI::class)
     val setHiddenInternalCompilerDataFunction =
-      context
-        .referenceFunctions(
+      finder
+        .findFunctions(
           CallableId(
             packageName = FqName(PACKAGE_NAME_INTERNAL),
             Name.identifier("hiddenInternalCompilerData"),
@@ -201,8 +202,8 @@ class KotlinLoggingIrGenerationExtension(
     val messageBuilderLambdaType = function0Class.typeWith(anyType)
     @OptIn(UnsafeDuringIrConstructionAPI::class)
     val toStringFunctionSymbol =
-      context
-        .referenceFunctions(
+      finder
+        .findFunctions(
           CallableId(
             packageName = FqName(PACKAGE_NAME_INTERNAL),
             Name.identifier("hiddenToStringSafe"),
@@ -213,7 +214,7 @@ class KotlinLoggingIrGenerationExtension(
             messageBuilderLambdaType.classifierOrFail
         }
     val kLoggerClassSymbol =
-      context.referenceClass(ClassId(FqName(PACKAGE_NAME), Name.identifier("KLogger")))!!
+      finder.findClass(ClassId(FqName(PACKAGE_NAME), Name.identifier("KLogger")))!!
   }
 
   class AccessorCallTransformer(
@@ -221,10 +222,11 @@ class KotlinLoggingIrGenerationExtension(
     private val loggingApiVersion: String?,
     private val sourceFile: SourceFile,
     private val context: IrPluginContext,
+    private val finder: DeclarationFinder,
     private val messageCollector: MessageCollector,
   ) : IrElementTransformerVoidWithContext(), FileLoweringPass {
 
-    private val typesHelper = TypesHelper(context)
+    private val typesHelper = TypesHelper(context, finder)
 
     @OptIn(UnsafeDuringIrConstructionAPI::class)
     fun findKLoggerExtensionFunction(
@@ -232,8 +234,8 @@ class KotlinLoggingIrGenerationExtension(
       extraFilter: (IrFunction) -> Boolean = { _ -> true },
     ): IrSimpleFunctionSymbol {
       val overloadedFunctionName = "${originalFunctionName}WithCompilerData"
-      return context
-        .referenceFunctions(
+      return finder
+        .findFunctions(
           CallableId(
             packageName = FqName(PACKAGE_NAME_INTERNAL),
             Name.identifier(overloadedFunctionName),

--- a/kotlin-plugin/src/main/kotlin/dev/nemecec/kotlinlogging/compiletimeplugin/KotlinLoggingIrGenerationExtension.kt
+++ b/kotlin-plugin/src/main/kotlin/dev/nemecec/kotlinlogging/compiletimeplugin/KotlinLoggingIrGenerationExtension.kt
@@ -88,6 +88,12 @@ internal val IrCall.regularArguments
 private val IrSimpleFunction.extensionReceiverValueParameter
   get() = parameters.firstOrNull({ it.kind == IrParameterKind.ExtensionReceiver })
 
+@OptIn(UnsafeDuringIrConstructionAPI::class)
+internal fun IrFunctionAccessExpression.insertExtensionReceiver(value: IrExpression?) {
+  val parameter = symbol.owner.parameters.first { it.kind == IrParameterKind.ExtensionReceiver }
+  arguments[parameter.indexInParameters] = value
+}
+
 private const val PACKAGE_NAME = "io.github.oshai.kotlinlogging"
 private const val PACKAGE_NAME_INTERNAL = "io.github.oshai.kotlinlogging.internal"
 


### PR DESCRIPTION
## Summary
- Upgrade Kotlin from 2.3.21 to 2.4.0
- Upgrade kotlin-compiler-extensions from 0.13.0+2.3.20 to 0.15.0+2.4.0
- Upgrade kctfork from 0.12.1 to 0.13.0
- Upgrade build-config plugin from 6.0.9 to 6.0.10
- Bump plugin version to 1.7.0-SNAPSHOT (incompatible Kotlin compiler API change)
- Add 2.4.0 row to the README compatibility matrix

## Adaptations for Kotlin 2.4.0
- `IrMemberAccessExpression.insertExtensionReceiver` (deprecated compat function) was removed in 2.4.0 — replaced with a local `IrFunctionAccessExpression.insertExtensionReceiver` helper built on the `parameters`/`arguments` API, alongside the existing regular-argument helpers
- Migrated symbol lookups from the deprecated `IrPluginContext.referenceClass`/`referenceFunctions` to the new `DeclarationFinder` API (`finderForSource()`, since the kotlin-logging symbols are library dependencies referenced from the compiled sources)
- Dropped the `-Xcontext-parameters` compiler flag — language version 2.4 enables context parameters by default and warns that the flag is redundant

## Notes
- Full test suite passes: 4100 tests, 0 failures