### PR TITLE
Pin jackson build-classpath deps to 2.21.5 to clear Dependabot alerts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,9 +12,10 @@ buildscript {
 
   configurations.classpath {
     resolutionStrategy.eachDependency {
-      if (requested.group == "com.fasterxml.jackson.core" && requested.name == "jackson-core") {
-        useVersion("2.18.6")
-        because("GHSA-72hv-8253-57qq")
+      if (requested.group.startsWith("com.fasterxml.jackson")) {
+        // Align to jackson-bom 2.21.5: core/databind track the patch line, annotations does not.
+        useVersion(if (requested.name == "jackson-annotations") "2.21" else "2.21.5")
+        because("GHSA-72hv-8253-57qq, GHSA-j3rv-43j4-c7qm, GHSA-rmj7-2vxq-3g9f, GHSA-hgj6-7826-r7m5, GHSA-5jmj-h7xm-6q6v")
       }
     }
   }


### PR DESCRIPTION
## What

Broaden the existing buildscript-classpath jackson pin from `jackson-core` only (2.18.6) to the whole `com.fasterxml.jackson` group, raised to the `jackson-bom:2.21.5` combination — **2.21.5** for core/databind/module-kotlin/dataformat-xml and **2.21** for `jackson-annotations` (which has no patch releases).

## Why

`jackson-databind` is a transitive **build-time-only** dependency of the Dokka and maven-publish plugins (it isn't shipped in the released plugin artifacts). Dependabot flagged four advisories against it:

| GHSA | Severity | Fixed in |
|------|----------|----------|
| GHSA-j3rv-43j4-c7qm | High | 2.18.8 |
| GHSA-rmj7-2vxq-3g9f | High | 2.18.8 |
| GHSA-hgj6-7826-r7m5 | Medium | 2.18.8 |
| GHSA-5jmj-h7xm-6q6v | Medium | 2.21.5 (2.19–2.21 line) |

All require deserializing attacker-controlled input with polymorphic typing, which does not happen on a build classpath talking to known endpoints, so real-world risk is negligible. This change simply keeps the alerts green, consistent with the pre-existing pinning approach.

`2.21.5` is the lowest released version outside the vulnerable range of **all four** advisories — note the 2.18 line has no fix for GHSA-5jmj-h7xm-6q6v (its 2.18-line fix, 2.18.9, was never released).

## Verification

`./gradlew build` passes (compile, tests, Dokka, and publish-to-test-repo all exercise jackson). The forced versions match the official `jackson-bom:2.21.5` alignment.