### PR TITLE
Also pin jackson for regular configurations to clear remaining Dependabot alerts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,6 +37,12 @@ allprojects {
         useVersion("1.84")
         because("GHSA-cj8j-37rh-8475, GHSA-c3fc-8qff-9hwx, GHSA-wg6q-6289-32hp")
       }
+      if (requested.group.startsWith("com.fasterxml.jackson")) {
+        // Also reaches the Dokka worker runtime classpath, which the buildscript rule does not.
+        // Align to jackson-bom 2.21.5: core/databind track the patch line, annotations does not.
+        useVersion(if (requested.name == "jackson-annotations") "2.21" else "2.21.5")
+        because("GHSA-72hv-8253-57qq, GHSA-j3rv-43j4-c7qm, GHSA-rmj7-2vxq-3g9f, GHSA-hgj6-7826-r7m5, GHSA-5jmj-h7xm-6q6v")
+      }
     }
   }
 }


### PR DESCRIPTION
## Why the alerts survived #70

#70 pinned jackson on the **buildscript classpath**, which fixed the Dokka/maven-publish *plugin* dependencies (now resolve 2.21.5). But GitHub's Automatic Dependency Submission also records jackson from Dokka's **`dokkaHtmlGeneratorRuntimeResolver`** configuration — a *regular* project configuration used to assemble the Dokka worker runtime — which still resolved `jackson-databind:2.15.3`. That version is in the vulnerable range of all four advisories (GHSA-j3rv-43j4-c7qm, GHSA-rmj7-2vxq-3g9f, GHSA-hgj6-7826-r7m5, GHSA-5jmj-h7xm-6q6v), so the alerts stayed open even after the graph refreshed post-merge.

## Fix

Mirror the jackson pin into the `allprojects { configurations.configureEach { resolutionStrategy } }` block that already pins bouncycastle. Gradle keeps buildscript (plugin) classpaths and regular project configurations in separate configuration containers, so a single `resolutionStrategy` block only reaches one of them — both rules are needed.

Same bom-aligned versions as #70: `2.21.5` for core/databind, `2.21` for `jackson-annotations`.

## Verification

- `dokkaHtmlGeneratorRuntimeResolver` now resolves `jackson-databind 2.15.3 -> 2.21.5`.
- `./gradlew build dokkaGenerate` passes (tests, Dokka HTML generation, publish-to-test-repo all exercise jackson).