### PR TITLE
Upgrade to Kotlin 2.4.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ For more details, see [What does it do (in detail)?](#what-does-it-do-in-detail)
 | 2.3.10         | 1.5.x (latest 1.5.1) |
 | 2.3.20         | 1.6.x (latest 1.6.1) |
 | 2.3.21         | 1.6.x (latest 1.6.1) |
-| 2.4.0          | 1.7.x (latest 1.7.0) |
+| 2.4.0          | 1.7.x (latest 1.7.1) |
+| 2.4.10         | 1.7.x (latest 1.7.1) |
 
 ## Usage
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlinversion = "2.4.0"
+kotlinversion = "2.4.10"
 ktfmt = "0.47"
 dokka = "2.2.0"
 build-config = "6.0.10"


### PR DESCRIPTION
Kotlin 2.4.10 was published on 2026-07-14; the build was still pinned to 2.4.0.

## Changes
- `kotlinversion` 2.4.0 → 2.4.10
- Compatibility matrix row for 2.4.10, and 2.4.0 row retargeted to the upcoming 1.7.1

## Notes
- `kotlin-compiler-extensions` stays at `0.15.0+2.4.0` — no 2.4.10-matched build has been published upstream yet. Same situation as the 2.3.21 upgrade, which shipped as 1.6.1 against the 2.3.20-built extensions.
- No compiler API adaptation was needed this time (the 2.4.0 upgrade needed the DeclarationFinder migration). Full suite passes: 4100 tests, 0 failures, plus the sample project (still on the 2.0.21 floor).
- The already-released 1.7.0 plugin compiles a consumer project on Kotlin 2.4.10 unchanged, so no user is blocked; this bump rebuilds against current Kotlin and documents the combination.

Note that Dependabot cannot raise this: `kotlinversion` is a bare `[versions]` entry consumed via `kotlin("jvm").version(libs.versions.kotlinversion)` with no `[plugins]` entry, so every Kotlin bump has to be manual.