### PR TITLE
Let Dependabot track the Kotlin version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,12 @@ updates:
     schedule:
       interval: "weekly"
     groups:
+      # Kotlin and the compiler extensions built against it move in lockstep and usually need a source change,
+      # so they get their own pull request instead of blocking the routine updates.
+      kotlin:
+        patterns:
+          - "org.jetbrains.kotlin*"
+          - "com.javiersc.kotlin*"
       minor-and-patch:
         update-types:
           - "patch"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,7 @@ buildscript {
 }
 
 plugins {
-  kotlin("jvm").version(libs.versions.kotlinversion).apply(false)
+  alias(libs.plugins.kotlin.jvm).apply(false)
   alias(libs.plugins.dokka)
   alias(libs.plugins.maven.publish)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,8 @@ kotlin-logging-jvm = { group = "io.github.oshai", name = "kotlin-logging-jvm", v
 logback-classic = { group = "ch.qos.logback", name = "logback-classic", version.ref = "logback" }
 
 [plugins]
+# Declared as a plugin alias (rather than kotlin("jvm").version(...)) so that Dependabot tracks the Kotlin version.
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlinversion" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 build-config = { id = "com.github.gmazzo.buildconfig", version.ref = "build-config" }
 maven-publish = { id = "com.vanniktech.maven.publish.base", version.ref = "maven-publish" }


### PR DESCRIPTION
Kotlin 2.4.10 shipped on 2026-07-14 and nothing flagged it — Dependabot has never proposed a Kotlin upgrade in this repo, so all of them (2.2.20, 2.2.21, 2.3.0, 2.3.10, 2.3.20, 2.3.21, 2.4.0) were hand-written commits.

The cause: `kotlinversion` is a bare `[versions]` entry consumed via `kotlin("jvm").version(libs.versions.kotlinversion)`, which Dependabot cannot map to a dependency coordinate. It does update `[plugins]` entries that use `version.ref` — that is how dokka, spotless, build-config and maven-publish get bumped — so declaring Kotlin the same way makes it visible.

## Changes
- `[plugins] kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlinversion" }`, applied in the root build as `alias(libs.plugins.kotlin.jvm) apply false`
- A dedicated `kotlin` Dependabot group covering `org.jetbrains.kotlin*` and `com.javiersc.kotlin*`

## Why the separate group
Kotlin and `kotlin-compiler-extensions` have to move together and an upgrade usually needs a compiler-API change, so those pull requests are expected to fail CI until adapted (as #55 did). Listing the group ahead of `minor-and-patch` keeps that failure out of the routine update pull request. It also stops the routine group from silently rewriting the extensions pin, which is what turned `0.9.0+2.2.20` into `0.10.0+` in 11cabb7.

## Verification
`./gradlew build` and `./gradlew -p sample build` both pass; the resolved Kotlin version is unchanged at 2.4.0 on this branch.

Stacked alongside #75 (the 2.4.10 upgrade); the two touch different lines of the catalog.