### PR TITLE
Exclude Kotlin from the minor-and-patch Dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,12 +6,17 @@ updates:
       interval: "weekly"
     groups:
       # Kotlin and the compiler extensions built against it move in lockstep and usually need a source change,
-      # so they get their own pull request instead of blocking the routine updates.
+      # so they get their own pull request instead of blocking the routine updates. Dependabot assigns a
+      # dependency to the most specific matching group and counts an update-types rule as more specific than
+      # a pattern, so minor-and-patch has to exclude them explicitly for this group to receive anything.
       kotlin:
         patterns:
           - "org.jetbrains.kotlin*"
           - "com.javiersc.kotlin*"
       minor-and-patch:
+        exclude-patterns:
+          - "org.jetbrains.kotlin*"
+          - "com.javiersc.kotlin*"
         update-types:
           - "patch"
           - "minor"


### PR DESCRIPTION
Follow-up to #76. The `kotlin` group it added never received anything.

The Dependabot run triggered by merging #76 shows why:

```
INFO Checking specificity for org.jetbrains.kotlin.jvm in group 'kotlin' (applies_to: version-updates)
INFO Skipping org.jetbrains.kotlin.jvm for group 'kotlin' - belongs to more specific group 'minor-and-patch'
INFO Checking specificity for com.javiersc.kotlin:kotlin-compiler-extensions in group 'kotlin'
INFO Skipping com.javiersc.kotlin:kotlin-compiler-extensions for group 'kotlin' - belongs to more specific group 'minor-and-patch'
INFO Marking group 'kotlin' as handled.
```

A dependency goes to the most specific matching group, and an `update-types` rule counts as more specific than a pattern — declaration order is irrelevant, contrary to what #76 claimed. Both Kotlin dependencies therefore landed back in `minor-and-patch`, so a Kotlin upgrade would still be bundled with the routine updates and could still rewrite the `kotlin-compiler-extensions` pin.

## Change
`exclude-patterns` for `org.jetbrains.kotlin*` and `com.javiersc.kotlin*` on `minor-and-patch`, leaving `kotlin` as the only group either can match.

## What already works
The visibility half of #76 is confirmed by the same run — Kotlin is now in the dependency snapshot and gets evaluated against the plugin portal:

```
INFO Checking if org.jetbrains.kotlin.jvm 2.4.10 needs updating
GET https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/maven-metadata.xml
```

No update was proposed, which is correct: 2.4.10 is the latest stable and Dependabot does not offer the 2.4.20-Beta2 prerelease.

Merging this triggers another Dependabot run, whose log will show whether `org.jetbrains.kotlin.jvm` now stays in the `kotlin` group.