### PR TITLE
Add a security policy

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities privately rather than opening a public issue.
+
+Use GitHub's private vulnerability reporting: open the
+[Security tab](https://github.com/nemecec/kotlin-logging-compile-time-plugin/security) and click
+**"Report a vulnerability"**. This creates a private advisory visible only to
+you and the maintainers.
+
+We aim to acknowledge reports within a few working days and will keep you
+informed as we investigate and prepare a fix. When a fix is released we publish
+a security advisory and credit the reporter unless you prefer to remain anonymous.
+
+## Supported Versions
+
+Security fixes are made against the latest released version. Please make sure you
+are on the most recent release before reporting an issue.


### PR DESCRIPTION
Adds `.github/SECURITY.md`, pointing reporters at GitHub private vulnerability reporting rather than public issues.

Private vulnerability reporting has been enabled on the repository, so the **Report a vulnerability** button the policy refers to is actually present on the Security tab.