### PR TITLE
Add CodeQL scanning and dependency-graph submission

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,65 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  # No branch filter: stacked pull requests target another topic branch
+  # rather than main, and they need checks just as much.
+  pull_request: { }
+  schedule:
+    # Weekly scan to catch newly published queries against unchanged code.
+    - cron: '17 4 * * 1'
+
+permissions:
+  contents: read
+
+env:
+  GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false -Dkotlin.incremental=false"
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Workflow files: nothing to compile, so CodeQL reads the sources directly.
+          - language: actions
+            build-mode: none
+          # A Kotlin compiler plugin has to be compiled before CodeQL can extract anything.
+          - language: java-kotlin
+            build-mode: manual
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v7
+
+      - uses: actions/setup-java@v5
+        if: matrix.build-mode == 'manual'
+        with:
+          distribution: 'temurin'
+          java-version: 21
+
+      - name: Setup Gradle
+        if: matrix.build-mode == 'manual'
+        uses: gradle/actions/setup-gradle@v6.3.0
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      # Compiles both kotlin-plugin and kotlin-plugin-gradle, which is everything
+      # CodeQL needs to see. The sample is a separate build and stays out of scope.
+      - name: Build
+        if: matrix.build-mode == 'manual'
+        run: ./gradlew compileKotlin
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,25 @@
+name: Dependency Submission
+
+# Submits the full Gradle dependency graph to GitHub so that Dependabot can raise
+# security alerts (and updates) for vulnerable transitive dependencies.
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  dependency-submission:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v7
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: 21
+
+      - name: Submit dependency graph
+        uses: gradle/actions/dependency-submission@v6.3.0


### PR DESCRIPTION
Follows the security policy added in #79, giving the Security tab something to actually report. Both mechanisms now live in the repository rather than in settings, matching the repos this one shares conventions with.

### CodeQL

The repository was on CodeQL **default setup**, configured for the `actions` language only — the Kotlin sources were never scanned. Default setup and an advanced configuration cannot coexist: with it enabled, GitHub rejects the SARIF an advanced workflow uploads. Default setup has been turned off and this workflow covers both languages instead:

| language | build mode | why |
| --- | --- | --- |
| `actions` | `none` | Workflow files, nothing to compile. Same coverage default setup gave. |
| `java-kotlin` | `manual` | A compiler plugin has to be compiled before CodeQL can extract anything. `./gradlew compileKotlin` covers both published modules; the sample is a separate build and stays out of scope. |

Runs on pushes to `main`, on every pull request, and weekly so newly published queries reach code that has not changed. The `pull_request` trigger has no branch filter on purpose, so stacked pull requests get the check too.

### Dependency submission

Submits the resolved Gradle dependency graph on pushes to `main`, so Dependabot alerts cover transitive dependencies it cannot infer from the build script.

This replaces GitHub's **Automatic Dependency Submission (Gradle)**, which has been doing the same job from repository settings. That setting has no REST endpoint and still needs to be switched off by hand under Settings → Advanced Security; until it is, both submitters run, which is redundant but harmless.

Dependabot alerts were already on; Dependabot **security updates** have now been enabled too, so alerts from the graph turn into pull requests.

Both workflows mirror the existing build workflow: Temurin 21, `gradle/actions` v6.3.0, and the same `GRADLE_OPTS`.