### PR TITLE
Pin jsoup to 1.23.1, make Dokka aggregation render, publish real Javadoc jars

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,6 +43,12 @@ allprojects {
         useVersion(if (requested.name == "jackson-annotations") "2.21" else "2.21.5")
         because("GHSA-72hv-8253-57qq, GHSA-j3rv-43j4-c7qm, GHSA-rmj7-2vxq-3g9f, GHSA-hgj6-7826-r7m5, GHSA-5jmj-h7xm-6q6v")
       }
+      if (requested.group == "org.jsoup" && requested.name == "jsoup") {
+        // Dokka's generator runtime pins 1.16.1. Dokka never calls Cleaner/Safelist, so the
+        // advisory is unreachable here, but the pin keeps the dependency graph clean.
+        useVersion("1.23.1")
+        because("GHSA-pmhh-3w7g-xqp8")
+      }
     }
   }
 }

--- a/kotlin-plugin-gradle/build.gradle.kts
+++ b/kotlin-plugin-gradle/build.gradle.kts
@@ -11,6 +11,7 @@ import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 plugins {
   kotlin("jvm")
   id("java-gradle-plugin")
+  alias(libs.plugins.dokka)
   alias(libs.plugins.maven.publish)
   alias(libs.plugins.build.config)
   alias(libs.plugins.spotless)

--- a/kotlin-plugin-gradle/build.gradle.kts
+++ b/kotlin-plugin-gradle/build.gradle.kts
@@ -55,7 +55,7 @@ gradlePlugin {
 
 mavenPublishing {
   configure(
-    GradlePlugin(javadocJar = JavadocJar.Empty())
+    GradlePlugin(javadocJar = JavadocJar.Dokka("dokkaGeneratePublicationHtml"))
   )
 }
 

--- a/kotlin-plugin/build.gradle.kts
+++ b/kotlin-plugin/build.gradle.kts
@@ -4,6 +4,7 @@ import com.vanniktech.maven.publish.KotlinJvm
 plugins {
   kotlin("jvm")
   kotlin("kapt")
+  alias(libs.plugins.dokka)
   alias(libs.plugins.maven.publish)
   alias(libs.plugins.build.config)
   alias(libs.plugins.spotless)

--- a/kotlin-plugin/build.gradle.kts
+++ b/kotlin-plugin/build.gradle.kts
@@ -35,7 +35,7 @@ buildConfig {
 
 mavenPublishing {
   configure(
-    KotlinJvm(javadocJar = JavadocJar.Empty())
+    KotlinJvm(javadocJar = JavadocJar.Dokka("dokkaGeneratePublicationHtml"))
   )
 }
 


### PR DESCRIPTION
Closes Dependabot alert 9, and fixes two unrelated documentation problems found while verifying it.

## jsoup 1.23.1 pin

Dokka 2.2.0's `dokka-base` hard-pins jsoup 1.16.1, which is affected by GHSA-pmhh-3w7g-xqp8 / CVE-2026-71497 (medium, affects `>= 1.14.3, < 1.23.1`): `Cleaner` mis-sanitises malformed HTML whose tag name ends in a control character, when a custom `Safelist` permits raw-text elements.

Nothing in this repo is exposed:

- jsoup reaches only the Dokka generator runtime, via `dokka-base` / `analysis-markdown` / `templating-plugin`. It is not on the buildscript classpath, so unlike Jackson only the project-configuration rule is needed.
- It appears in no published POM, so consumers of the plugin were never exposed.
- No Dokka jar references `org/jsoup/safety` at all, so `Cleaner` and `Safelist` are never called and the custom-Safelist precondition cannot be met.
- jsoup only ever parses Dokka's own generated HTML, never untrusted input.

The pin is there to keep the submitted dependency graph clean. No newer Dokka helps: 2.2.0 is current and still pins 1.16.1.

## Dokka wiring

The root project applies Dokka, declares `dokka(project(...))` for both modules, and configures `dokkaSourceSets` inside `subprojects { pluginManager.withPlugin("org.jetbrains.dokka") { ... } }`. Neither subproject applied Dokka, so that guard never fired: the modules contributed nothing to the aggregate, and `dokkaGenerate` reported BUILD SUCCESSFUL while writing an empty publication. `build/dokka/html` contained zero HTML files.

Applying the plugin in both modules renders 100 pages covering both, and activates the source links, internal-package suppression and `jdkVersion` settings that were already configured but dormant.

## Javadoc jars

Both modules passed `JavadocJar.Empty()`, so the published `-javadoc.jar` artifacts contained nothing but a MANIFEST. With per-module Dokka now applied they can carry the generated API docs, via `JavadocJar.Dokka("dokkaGeneratePublicationHtml")`.

Result: `kotlin-plugin` ships 157 entries (82 HTML pages), `kotlin-plugin-gradle` 82 entries (16 HTML pages), each with a root `index.html`, correct asset links, and its own package and class pages.

## Verification

- `./gradlew clean build` — 38 tasks executed, tests run, BUILD SUCCESSFUL.
- `dependencyInsight --dependency org.jsoup:jsoup --configuration "dokkaHtmlGeneratorRuntimeResolver~internal"` resolves `1.16.1 -> 1.23.1`, selected by rule GHSA-pmhh-3w7g-xqp8.
- Aggregated docs render 100 HTML files with `index.html` and both module directories; 92 files carry GitHub source links; the `compiletimeplugin.internal` package is absent as configured.
- Javadoc jars extracted and inspected: real package and class pages, e.g. `dev.nemecec.kotlinlogging.compiletimeplugin/-kotlin-logging-ir-generation-extension/index.html`.
- jsoup is absent from every POM in `build/testMaven`.

The wiring fix also gives the pin a real smoke test: doc generation now exercises jsoup 1.23.1 in the Dokka worker, which previously never ran.